### PR TITLE
rest_client: fix error during error exception

### DIFF
--- a/rest_client.py
+++ b/rest_client.py
@@ -117,7 +117,7 @@ class RestClient(object):
             response.raise_for_status()
             return response
         except Exception as e:
-            raise RestCallException(e, leaf_route, f'POST {response.url} failed ({response.status_code}): {response.text}')
+            raise RestCallException(e, leaf_route, response, f'POST {response.url} failed ({response.status_code}): {response.text}')
 
     @classmethod
     def __convert_to_json(cls, object):


### PR DESCRIPTION
Hi, this fixes an error when the users puts the wrong credentials, RestCallException was missing an argument, causing:
```
[...]
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "garmin.py", line 341, in <module>
    main(sys.argv[1:])
  File "garmin.py", line 322, in main
    download_data(args.overwrite, args.latest, args.stats)
  File "garmin.py", line 110, in download_data
    if not download.login():
  File "/home/grimler/projects/GarminDB/download_garmin.py", line 143, in login
    response = self.sso_rest_client.post(self.garmin_connect_sso_login, post_headers, params, data)
  File "/home/grimler/projects/GarminDB/utilities/rest_client.py", line 120, in post
    raise RestCallException(e, leaf_route, f'POST {response.url} failed ({response.status_code}): {response.text}')
TypeError: __init__() missing 1 required positional argument: 'error'
```