### PR TITLE
Fix 402 Client Error - Adding `nk: NT` header to `default_headers`

### DIFF
--- a/rest_client.py
+++ b/rest_client.py
@@ -69,7 +69,8 @@ class RestClient(object):
 
     default_headers = {
         'User-Agent'    : agent,
-        'Accept'        : 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+        'Accept'        : 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'nk'            : 'NT' # Avoids 402 error in some requests
     }
 
     def __init__(self, session, host, base_route, protocol=RestProtocol.https, port=443):


### PR DESCRIPTION
Fixes https://github.com/tcgoetz/GarminDB/issues/109 with @matthiaswh observation https://github.com/tcgoetz/GarminDB/issues/109#issuecomment-785047086. 

The `nk: NT` header might be moved elsewhere when more is known about the issue. Until then this fixed  HTTP requests for me.