### PR TITLE
Declare CREATE VIEW SQL expression as SQLAlchemy TextClause

### DIFF
--- a/idbutils/db_object.py
+++ b/idbutils/db_object.py
@@ -8,7 +8,7 @@ import types
 import logging
 import datetime
 
-from sqlalchemy import func, desc, extract, and_, literal_column
+from sqlalchemy import func, desc, extract, and_, literal_column, text
 from sqlalchemy.orm import synonym, Query
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.attributes import set_attribute
@@ -178,7 +178,7 @@ class DbObject():
 
     @classmethod
     def __create_view_if_not_exists(cls, session, view_name, query_str):
-        result = session.execute('CREATE VIEW IF NOT EXISTS ' + view_name + ' AS ' + query_str)
+        result = session.execute(text('CREATE VIEW IF NOT EXISTS ' + view_name + ' AS ' + query_str))
         logger.debug("Created join view %s using query %s: %r", view_name, query_str, result)
 
     @classmethod


### PR DESCRIPTION
Initializing GarminDB failed for me with the following exception

```
Traceback (most recent call last):
  File "/home/rsto/garmindb_env/bin/garmindb_cli.py", line 358, in <module>
    main(sys.argv[1:])
  File "/home/rsto/garmindb_env/bin/garmindb_cli.py", line 339, in main
    download_data(args.overwrite, args.latest, args.stats)
  File "/home/rsto/garmindb_env/bin/garmindb_cli.py", line 136, in download_data
    date, days = __get_date_and_days(GarminDb(db_params_dict), latest, Sleep, Sleep.total_sleep, 'sleep')
  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/idbutils/db.py", line 66, in __init__
    self.init_table(table)
  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/idbutils/db.py", line 76, in init_table
    table.setup(self)
  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/idbutils/db_object.py", line 72, in setup
    cls.create_view(db)
  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/garmindb/garmindb/garmin_db.py", line 120, in create_view
    cls.create_join_view(db, cls._get_default_view_name(), cols, Device, order_by=cls.timestamp.desc())
  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/idbutils/db_object.py", line 202, in create_join_view
    raise DbViewException(f"Failed to create DB view {view_name} with table {join_table}", e)
idbutils.db_object.DbViewException: Failed to create DB view device_info_view with table <class 'garmindb.garmindb.garmin_db.Device'>:Textual SQL expression 'CREATE VIEW IF NOT EXISTS...' should be explicitly declared as text('CREATE VIEW IF NOT EXISTS...')
```
This exception is thrown by my installation of latest stable SQLAlchemy 2.0.2
```

  File "/home/rsto/garmindb_env/lib/python3.9/site-packages/sqlalchemy/sql/coercions.py", line 602, in _no_text_coercion
    raise exc_cls(
sqlalchemy.exc.ArgumentError: Textual SQL expression 'CREATE VIEW IF NOT EXISTS...' should be explicitly declared as text('CREATE VIEW IF NOT EXISTS...')
```

The patch in this pull request fixes that.

And: thanks for making this available, I just got started with GarminDB but it looks like a great tool!
